### PR TITLE
Add position index + example

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     'func-names': 0,
     'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
     'class-methods-use-this': 0, // strange rule. It doesn't allow to create method render() without this
-    'no-case-declarations': 0 // otherwise code is very ugly
+    'no-case-declarations': 0, // otherwise code is very ugly
+    'no-continue': 0 // why would avoid continue?
   }
 };

--- a/demo/src/App.css
+++ b/demo/src/App.css
@@ -10,6 +10,10 @@
     width: 200px;
 }
 
+.sidebar > div {
+    margin-bottom: 10px;
+}
+
 .viewer {
     max-height: 500px;
     overflow: auto;

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -3,24 +3,15 @@ import 'uast-viewer/dist/default-theme.css';
 import './App.css';
 import UncontrolledUAST from './UncontrolledUAST';
 import ControlledUAST from './ControlledUAST';
+import PosIndexUAST from './PosIndexUAST';
 
 class App extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = { showLocations: false };
-    this.onShowLocation = this.onShowLocation.bind(this);
-  }
-
-  onShowLocation() {
-    this.setState({ showLocations: !this.state.showLocations });
-  }
-
   render() {
     return (
       <div className="app">
         <UncontrolledUAST />
         <ControlledUAST />
+        <PosIndexUAST />
       </div>
     );
   }

--- a/demo/src/ControlledUAST.js
+++ b/demo/src/ControlledUAST.js
@@ -11,16 +11,17 @@ class ControlledUAST extends Component {
       showLocations: false,
       toggleOnlyEven: false,
       uast: transformer(uastJson),
-      hoveredId: null
+      hoveredId: null,
+      highlighted: false
     };
 
     this.onNodeHover = this.onNodeHover.bind(this);
     this.onNodeToggle = this.onNodeToggle.bind(this);
 
-    this.onShowLocation = this.onShowLocation.bind(this);
     this.onToggleOnlyEven = this.onToggleOnlyEven.bind(this);
     this.onExpandAll = this.onExpandAll.bind(this);
     this.onCollapseAll = this.onCollapseAll.bind(this);
+    this.onHighlight = this.onHighlight.bind(this);
   }
 
   onNodeHover(id, prevId) {
@@ -44,10 +45,6 @@ class ControlledUAST extends Component {
       }
     };
     this.setState({ uast: newUast });
-  }
-
-  onShowLocation() {
-    this.setState({ showLocations: !this.state.showLocations });
   }
 
   onToggleOnlyEven() {
@@ -76,6 +73,24 @@ class ControlledUAST extends Component {
     }, {});
 
     this.setState({ uast: newUast });
+  }
+
+  onHighlight() {
+    const { uast, highlighted } = this.state;
+    const newUast = Object.keys(this.state.uast).reduce((acc, key) => {
+      const node = uast[key];
+      const newNode = node.Roles.includes('Identifier')
+        ? {
+            ...node,
+            highlighted: !highlighted
+          }
+        : node;
+
+      acc[key] = newNode;
+      return acc;
+    }, {});
+
+    this.setState({ uast: newUast, highlighted: !highlighted });
   }
 
   render() {
@@ -111,6 +126,11 @@ class ControlledUAST extends Component {
         </div>
         <div>
           <button onClick={this.onCollapseAll}>collapse all</button>
+        </div>
+        <div>
+          <button onClick={this.onHighlight}>
+            Toggle highlight for all nodes with Identifier role
+          </button>
         </div>
       </Case>
     );

--- a/demo/src/PosIndexUAST.js
+++ b/demo/src/PosIndexUAST.js
@@ -1,0 +1,127 @@
+import React, { Component } from 'react';
+import {
+  transformer,
+  DEFAULT_EXPAND_LEVEL,
+  hoverNodeById,
+  highlightNodeById,
+  PositionIndex,
+  makePositionIndexHook,
+  getNodePosition
+} from 'uast-viewer';
+import Case from './Case';
+import uastJson from './uast.json';
+
+class PosIndexUAST extends Component {
+  constructor(props) {
+    super(props);
+
+    this.posIndex = new PositionIndex();
+
+    this.state = {
+      uast: transformer(
+        uastJson,
+        DEFAULT_EXPAND_LEVEL,
+        makePositionIndexHook(this.posIndex)
+      ),
+      showLocations: false,
+      // control highlighted node
+      line: 1,
+      col: 1,
+      lastHighlighted: null,
+      posNotFound: false,
+      // position of hovered node
+      from: null,
+      to: null
+    };
+
+    this.onNodeHover = this.onNodeHover.bind(this);
+    this.onNodeToggle = this.onNodeToggle.bind(this);
+
+    this.onHighlightNode = this.onHighlightNode.bind(this);
+  }
+
+  onNodeHover(id, prevId) {
+    const { uast } = this.state;
+    const pos = getNodePosition(uast[id]);
+
+    this.setState({
+      uast: hoverNodeById(uast, id, prevId),
+      from: pos.from,
+      to: pos.to
+    });
+  }
+
+  onNodeToggle(id) {
+    const { uast } = this.state;
+    const newUast = {
+      ...uast,
+      [id]: {
+        ...uast[id],
+        expanded: !uast[id].expanded
+      }
+    };
+    this.setState({ uast: newUast });
+  }
+
+  onHighlightNode() {
+    const { uast, line, col, lastHighlighted } = this.state;
+    const pos = this.posIndex.get({ Line: +line, Col: +col });
+    if (!pos) {
+      this.setState({ posNotFound: true });
+      return;
+    }
+    const newUast = highlightNodeById(uast, pos.id, lastHighlighted);
+    this.setState({
+      uast: newUast,
+      lastHighlighted: pos.id,
+      posNotFound: false
+    });
+  }
+
+  render() {
+    const { from, to } = this.state;
+    const hoveredPos =
+      from != null && to != null
+        ? `${from.line}:${from.ch}-${to.line}:${to.ch}`
+        : null;
+
+    return (
+      <Case
+        title="Controlled mode with position index"
+        description="simple way to integrate tree with any text editor"
+        uast={this.state.uast}
+        onNodeHover={this.onNodeHover}
+        onNodeToggle={this.onNodeToggle}
+      >
+        <div>Hovered position: {hoveredPos}</div>
+        <div>
+          Select node by position in source code:<br />
+          Line:{' '}
+          <input
+            type="number"
+            value={this.state.line}
+            onChange={e => this.setState({ line: e.target.value })}
+          />
+          <br />
+          Col:{' '}
+          <input
+            type="number"
+            value={this.state.col}
+            onChange={e => this.setState({ col: e.target.value })}
+          />
+          <br />
+          {this.state.posNotFound && (
+            <div>Node for this position not found</div>
+          )}
+          <input
+            type="submit"
+            value="highlight"
+            onClick={this.onHighlightNode}
+          />
+        </div>
+      </Case>
+    );
+  }
+}
+
+export default PosIndexUAST;

--- a/src/Node.js
+++ b/src/Node.js
@@ -37,7 +37,7 @@ class Node extends Component {
         label="Node"
         collapsed={!node.expanded}
         hovered={node.hovered}
-        higlighted={node.higlighted}
+        highlighted={node.highlighted}
         toggle={this.handleToggle}
         onMouseMove={this.handleMouseMove}
       >

--- a/src/PositionIndex.js
+++ b/src/PositionIndex.js
@@ -1,0 +1,127 @@
+function hasEnd(node) {
+  return node.end && node.end.Line && node.end.Col;
+}
+
+function endsAfter(node, targetLine, targetCol) {
+  return (
+    node.end.Line > targetLine ||
+    (node.end.Line === targetLine && node.end.Col > targetCol)
+  );
+}
+
+function findSmallerContainerInColNodes(columnNodes, targetLine, targetCol) {
+  let candidateNode;
+  let closestEndLine = Number.MAX_VALUE;
+  let closestEndCol = Number.MAX_VALUE;
+
+  columnNodes.forEach(node => {
+    if (!hasEnd(node) || !endsAfter(node, targetLine, targetCol)) {
+      return;
+    }
+
+    if (
+      node.end.Line < closestEndLine ||
+      (node.end.Line === closestEndLine && node.end.Col < closestEndCol)
+    ) {
+      candidateNode = node;
+      closestEndLine = node.end.Line;
+      closestEndCol = node.end.Col;
+    }
+  });
+
+  return candidateNode;
+}
+
+function findContainerInLineNodes(
+  lineNodes,
+  targetLine,
+  targetCol,
+  startFromTargetCol
+) {
+  let candidate;
+  for (
+    let col = startFromTargetCol ? targetCol : lineNodes.length - 1;
+    col > 0;
+    col--
+  ) {
+    if (!lineNodes[col]) {
+      continue;
+    }
+
+    candidate = findSmallerContainerInColNodes(
+      lineNodes[col],
+      targetLine,
+      targetCol
+    );
+    if (candidate) {
+      break;
+    }
+  }
+
+  return candidate;
+}
+
+function findContainer(idx, targetLine, targetCol) {
+  let candidate;
+  let firstLookup = true;
+  for (let line = targetLine; line > 0; line--) {
+    if (!idx[line]) {
+      continue;
+    }
+
+    candidate = findContainerInLineNodes(
+      idx[line],
+      targetLine,
+      targetCol,
+      firstLookup
+    );
+    if (candidate) {
+      break;
+    }
+
+    firstLookup = false;
+  }
+
+  return candidate;
+}
+
+export default class PositionIndex {
+  constructor() {
+    this.index = [];
+  }
+
+  clear() {
+    this.index = [];
+  }
+
+  add(node) {
+    if (!node.end || !node.end.Line || !node.end.Col) {
+      return;
+    }
+
+    const { Line: line, Col: col } = node.start;
+    const idx = this.index;
+
+    if (!idx[line]) {
+      idx[line] = [];
+      idx[line][col] = [node];
+      return;
+    }
+
+    if (!idx[line][col]) {
+      idx[line][col] = [node];
+      return;
+    }
+
+    // prevent duplicates on the index
+    if (idx[line][col].indexOf(node) >= 0) {
+      return;
+    }
+
+    idx[line][col].push(node);
+  }
+
+  get({ Line: line, Col: col }) {
+    return findContainer(this.index, line, col);
+  }
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,3 @@
-/* disable because here will be more functions later,
-   it's incorrect to export this function as default */
-/* eslint import/prefer-default-export: 0 */
 export function hoverNodeById(uast, id, prevId) {
   const node = uast[id];
   const newUast = {
@@ -18,4 +15,55 @@ export function hoverNodeById(uast, id, prevId) {
   }
 
   return newUast;
+}
+
+export function highlightNodeById(uast, id, prevId) {
+  const node = uast[id];
+  const newUast = {
+    ...uast,
+    [id]: {
+      ...node,
+      highlighted: true
+    }
+  };
+  if (prevId !== null) {
+    newUast[prevId] = {
+      ...newUast[prevId],
+      highlighted: false
+    };
+  }
+
+  return newUast;
+}
+
+export function getNodePosition(node) {
+  const { StartPosition: start, EndPosition: end } = node;
+
+  let from = null;
+  let to = null;
+  if (start && start.Line && start.Col) {
+    from = {
+      line: start.Line - 1,
+      ch: start.Col - 1
+    };
+  }
+
+  if (end && end.Line && end.Col) {
+    to = {
+      line: end.Line - 1,
+      ch: end.Col - 1
+    };
+  }
+
+  return { from, to };
+}
+
+export function makePositionIndexHook(posIndex) {
+  return function posIndexHook(node) {
+    posIndex.add({
+      id: node.id,
+      start: node.StartPosition,
+      end: node.EndPosition
+    });
+  };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,20 @@
 import UASTViewer from './UASTViewer';
-import transformer from './transformer';
-import { hoverNodeById } from './helpers';
+import PositionIndex from './PositionIndex';
+import transformer, { DEFAULT_EXPAND_LEVEL } from './transformer';
+import {
+  hoverNodeById,
+  highlightNodeById,
+  getNodePosition,
+  makePositionIndexHook
+} from './helpers';
 
 export default UASTViewer;
-export { transformer, hoverNodeById };
+export {
+  transformer,
+  DEFAULT_EXPAND_LEVEL,
+  hoverNodeById,
+  highlightNodeById,
+  getNodePosition,
+  PositionIndex,
+  makePositionIndexHook
+};

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -1,6 +1,6 @@
-const DEFAULT_EXPAND_LEVEL = 2;
+export const DEFAULT_EXPAND_LEVEL = 2;
 
-function transformer(uastJson, expandLevel = DEFAULT_EXPAND_LEVEL) {
+function transformer(uastJson, expandLevel = DEFAULT_EXPAND_LEVEL, ...hooks) {
   const tree = {};
   let id = 0;
 
@@ -20,6 +20,7 @@ function transformer(uastJson, expandLevel = DEFAULT_EXPAND_LEVEL) {
       );
     }
     tree[curId] = node;
+    hooks.forEach(hook => hook(node));
 
     return curId;
   }


### PR DESCRIPTION
Based on #4

This PR adds position index which allows to integrate uast tree with source code editor/viewer.

<img width="735" alt="screen shot 2018-05-16 at 15 45 35" src="https://user-images.githubusercontent.com/406916/40120758-50b44fde-5920-11e8-8218-b953ab5cd1a6.png">

An app can import hook to get a position of hovered node or find the node by position.